### PR TITLE
Automate PyPI publication and GitHub releases

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,49 @@
+name: Bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version part to bump"
+        required: true
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Bump version
+        id: bump
+        run: |
+          uv version --bump ${{ inputs.bump }} --no-sync
+          echo "version=$(uv version --short)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and tag
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          git add pyproject.toml uv.lock
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          git tag "v${{ steps.bump.outputs.version }}"
+          git push origin "HEAD:${{ github.ref_name }}"
+          git push origin "v${{ steps.bump.outputs.version }}"
+
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release.yml --ref "v${{ steps.bump.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Verify tag matches package version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version="$(uv version --short)"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag v$tag_version does not match pyproject.toml version $pkg_version"
+            exit 1
+          fi
+      - run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  test:
+    name: Tests (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --frozen
+      - run: uv run pytest
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/como/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Extract changelog section
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="## $version ##" '
+            $0 == ver {found=1; next}
+            found && /^## / {exit}
+            found {print}
+          ' HISTORY.md > release_notes.md
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          body_path: release_notes.md
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
     needs: [build, test]
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: release
       url: https://pypi.org/project/como/
     permissions:
       id-token: write

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ uv run pytest             # run tests with coverage
 uv run pre-commit install # enable ruff + ty pre-commit hooks
 ```
 
+## Releasing
+
+Releases are automated via GitHub Actions:
+
+1. Run the **Bump version** workflow (`Actions` → `Bump version` → `Run workflow`, choose `patch`/`minor`/`major`). It bumps `pyproject.toml`/`uv.lock`, commits, tags (`vX.Y.Z`), and triggers the release workflow.
+2. The **Release** workflow (`.github/workflows/release.yml`) then builds the sdist/wheel, runs the test suite, publishes to PyPI, and creates a GitHub Release with the built artifacts attached and notes drawn from `HISTORY.md` (falling back to GitHub's auto-generated notes).
+
+Pushing a `v*.*.*` tag directly also triggers the release workflow, so a manual `git tag vX.Y.Z && git push origin vX.Y.Z` works too.
+
+Publishing to PyPI uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token is stored in the repo. This requires a one-time setup on PyPI: on the [`como` project's](https://pypi.org/manage/project/como/publishing/) publishing settings, add a trusted publisher for this repository, workflow `release.yml`, and environment `pypi`.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Releases are automated via GitHub Actions:
 
 Pushing a `v*.*.*` tag directly also triggers the release workflow, so a manual `git tag vX.Y.Z && git push origin vX.Y.Z` works too.
 
-Publishing to PyPI uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token is stored in the repo. This requires a one-time setup on PyPI: on the [`como` project's](https://pypi.org/manage/project/como/publishing/) publishing settings, add a trusted publisher for this repository, workflow `release.yml`, and environment `pypi`.
+Publishing to PyPI uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token is stored in the repo. This requires a one-time setup on PyPI: on the [`como` project's](https://pypi.org/manage/project/como/publishing/) publishing settings, add a trusted publisher for this repository, workflow `release.yml`, and environment `release`.
 
 ## License
 


### PR DESCRIPTION
Add a tag-triggered release workflow that builds the package, runs
tests, publishes to PyPI via trusted publishing (OIDC, no stored
token), and creates a GitHub Release with the built artifacts and
notes drawn from HISTORY.md. Add a companion bump-version workflow
to bump pyproject.toml/uv.lock, tag, and kick off the release in one
click. Document the release flow and one-time PyPI trusted-publisher
setup in the README.