### PR TITLE
Automate PyPI publication and GitHub releases

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,49 @@
+name: Bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version part to bump"
+        required: true
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Bump version
+        id: bump
+        run: |
+          uv version --bump ${{ inputs.bump }} --no-sync
+          echo "version=$(uv version --short)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and tag
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          git add pyproject.toml uv.lock
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          git tag "v${{ steps.bump.outputs.version }}"
+          git push origin "HEAD:${{ github.ref_name }}"
+          git push origin "v${{ steps.bump.outputs.version }}"
+
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release.yml --ref "v${{ steps.bump.outputs.version }}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,11 +18,11 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Bump version
         id: bump

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -10,6 +10,11 @@ on:
         options: [patch, minor, major]
         default: patch
 
+# Two bumps at once would race on pushing the version commit and tag.
+concurrency:
+  group: bump-version
+  cancel-in-progress: false
+
 permissions:
   contents: write
   actions: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
       - name: Verify tag matches package version
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
@@ -25,7 +25,7 @@ jobs:
             exit 1
           fi
       - run: uv build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -34,8 +34,8 @@ jobs:
     name: Tests (pytest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen
       - run: uv run pytest
 
@@ -49,7 +49,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -62,8 +62,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -75,7 +75,7 @@ jobs:
             found && /^## / {exit}
             found {print}
           ' HISTORY.md > release_notes.md
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           body_path: release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
       - "v*.*.*"
   workflow_dispatch:
 
+# Serialize releases globally: publishing is not idempotent, and a cancelled
+# run can leave PyPI updated with no matching GitHub release.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Verify tag matches package version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version="$(uv version --short)"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag v$tag_version does not match pyproject.toml version $pkg_version"
+            exit 1
+          fi
+      - run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  test:
+    name: Tests (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --frozen
+      - run: uv run pytest
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/como/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Extract changelog section
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="## $version ##" '
+            $0 == ver {found=1; next}
+            found && /^## / {exit}
+            found {print}
+          ' HISTORY.md > release_notes.md
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          body_path: release_notes.md
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,21 @@ jobs:
             echo "::error::Tag v$tag_version does not match pyproject.toml version $pkg_version"
             exit 1
           fi
+      # PyPI keys distributions on (project, version, type), not content, so a
+      # published version can never be overwritten -- only superseded by a new
+      # one. Fail here with a clear message rather than at the upload step.
+      - name: Verify version is not already on PyPI
+        run: |
+          version="$(uv version --short)"
+          # `|| true` keeps a network blip from failing the step: steps run under
+          # `bash -e`, so the assignment would otherwise inherit curl's exit code.
+          # Only a definitive 200 blocks; the upload step stays the real judge.
+          code="$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' \
+            "https://pypi.org/pypi/como/$version/json" || true)"
+          if [ "$code" = "200" ]; then
+            echo "::error::como $version is already on PyPI -- bump the version and re-tag"
+            exit 1
+          fi
       - run: uv build
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
     needs: [build, test]
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: release
       url: https://pypi.org/project/como/
     permissions:
       id-token: write

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ uv run pytest             # run tests with coverage
 uv run pre-commit install # enable ruff + ty pre-commit hooks
 ```
 
+## Releasing
+
+Releases are automated via GitHub Actions:
+
+1. Run the **Bump version** workflow (`Actions` → `Bump version` → `Run workflow`, choose `patch`/`minor`/`major`). It bumps `pyproject.toml`/`uv.lock`, commits, tags (`vX.Y.Z`), and triggers the release workflow.
+2. The **Release** workflow (`.github/workflows/release.yml`) then builds the sdist/wheel, runs the test suite, publishes to PyPI, and creates a GitHub Release with the built artifacts attached and notes drawn from `HISTORY.md` (falling back to GitHub's auto-generated notes).
+
+Pushing a `v*.*.*` tag directly also triggers the release workflow, so a manual `git tag vX.Y.Z && git push origin vX.Y.Z` works too.
+
+Publishing to PyPI uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token is stored in the repo. This requires a one-time setup on PyPI: on the [`como` project's](https://pypi.org/manage/project/como/publishing/) publishing settings, add a trusted publisher for this repository, workflow `release.yml`, and environment `pypi`.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Releases are automated via GitHub Actions:
 
 Pushing a `v*.*.*` tag directly also triggers the release workflow, so a manual `git tag vX.Y.Z && git push origin vX.Y.Z` works too.
 
-Publishing to PyPI uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token is stored in the repo. This requires a one-time setup on PyPI: on the [`como` project's](https://pypi.org/manage/project/como/publishing/) publishing settings, add a trusted publisher for this repository, workflow `release.yml`, and environment `pypi`.
+Publishing to PyPI uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token is stored in the repo. This requires a one-time setup on PyPI: on the [`como` project's](https://pypi.org/manage/project/como/publishing/) publishing settings, add a trusted publisher for this repository, workflow `release.yml`, and environment `release`.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds two workflows so cutting a release is a single action instead of a manual build-and-upload.

**`release.yml`** — triggered by a `v*.*.*` tag push (or an explicit dispatch). It:
- verifies the tag matches `pyproject.toml`'s version, and that the version isn't already on PyPI, before building anything
- builds the sdist/wheel and runs the test suite
- publishes to PyPI via Trusted Publishing (OIDC, environment `release`) — no API token stored in the repo
- creates a GitHub Release with the built artifacts attached and notes taken from the matching `HISTORY.md` section, followed by GitHub's auto-generated notes

**`bump-version.yml`** — manual `workflow_dispatch` (`patch`/`minor`/`major`). Bumps `pyproject.toml` and `uv.lock`, commits, tags, and dispatches the release.

### Notes on a few non-obvious choices

- **`release.yml` declares `workflow_dispatch` even though tags are the normal trigger.** `bump-version.yml` pushes its tag with the default `GITHUB_TOKEN`, and GitHub suppresses `push`-triggered runs from `GITHUB_TOKEN`-authored pushes to prevent recursion. So the tag landing does *not* start the release on its own — `bump-version.yml` has to dispatch it explicitly, which requires this trigger. A tag you push yourself triggers it the ordinary way.
- **Both workflows use `cancel-in-progress: false`.** Cancelling a run mid-publish can leave a version live on PyPI with no matching GitHub release, so concurrent releases queue rather than cancel.
- **No `skip-existing` on the publish step.** PyPI keys distributions on (project, version, type) rather than content, so it would silently swallow a genuine "different build, same version" mistake and leave the GitHub release's artifacts disagreeing with PyPI's. The pre-flight check catches that case loudly instead.
- **Action versions** match master's current Dependabot pins; `download-artifact` is on v8 and `action-gh-release` on v3, which are their current majors.

## Test plan

- [x] All workflow YAML parses; job and step graphs are as intended
- [x] `uv version --bump` updates both `pyproject.toml` and `uv.lock` (verified in a scratch copy)
- [x] Changelog extraction verified against the existing `## 0.8.0 ##` section of `HISTORY.md`
- [x] PyPI pre-flight check exercised under `bash -e` against live PyPI using the step's exact `run:` text — blocks on `0.7.0` (published, exits 1 with a clear message), proceeds on `0.8.0` (404), and fails open when PyPI is unreachable
- [x] Existing CI (ruff, ty, pytest) green on the head commit
- [ ] End-to-end release run — inherently unexercisable until a real tag is pushed

## Before the first release

- The `release` environment must exist on the repo and match the trusted-publisher entry configured on PyPI (repo `cwoebker/como`, workflow `release.yml`, environment `release`). Adding required reviewers to that environment will pause `publish-pypi` for approval on every release.
- Merge before tagging: a tag runs the workflow as it existed at the tagged commit, so tagging a commit from before this lands does nothing at all.